### PR TITLE
fix a bug when an allowed import precedes a banned one it's not detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.1
+- fix: Banned imports not detected when valid imports precede them
+- chore: Upgraded analyzer to support versions up to 9.0.0
+- chore: Upgraded analyzer_plugin to support versions up to 0.14.0
+
 ## 0.3.0
 - feat: Support banned relative imports
 - chore: Upgraded analyzer to 6.4.1

--- a/example/lib/domain/domain_test_with_banned_import.dart
+++ b/example/lib/domain/domain_test_with_banned_import.dart
@@ -1,0 +1,18 @@
+// This file demonstrates a banned import violation
+// Domain layer should NOT import from Presentation layer
+// Testing bug: when first import is valid, banned imports after it are not detected
+
+import 'package:example/domain/domain_class.dart'; // Valid import (same layer)
+import 'package:example/presentation/presentation_class.dart'; // BANNED import
+
+class DomainTestClass {
+  void performAction() {
+    // Valid usage
+    final domain = DomainClass();
+
+    // This violates the architecture rules:
+    // Domain layer is importing from Presentation layer
+    final presentation = PresentationClass();
+    presentation.call();
+  }
+}

--- a/lib/src/analyzers/file_analyzers/analyzer_imports/file_analyzer_imports.dart
+++ b/lib/src/analyzers/file_analyzers/analyzer_imports/file_analyzer_imports.dart
@@ -40,7 +40,7 @@ class FileAnalyzerImports implements FileAnalyzer {
       if (bannedLayers == null) return;
 
       if (!resolvedAsBannedImport(import, path, bannedLayers)) {
-        return;
+        continue;
       }
 
       final layerConfig = ImportDirectiveUtils.getConfigFromLastInPath(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  analyzer: '>=4.1.0 <7.0.0'
-  analyzer_plugin: '>=0.10.0 <0.12.0'
+  analyzer: '>=4.1.0 <9.0.0'
+  analyzer_plugin: '>=0.10.0 <0.14.0'
   args: ^2.4.2
   collection: ^1.18.0
   file: ^7.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/Iteo/architecture_linter
 repository: https://github.com/Iteo/architecture_linter
 # Remember, increase also architecture_linter version
 # in tools/analyzer_plugin/pubspec.yaml to the same version
-version: 0.3.0
+version: 0.3.1
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/test/analyzers/file_analyzers/analyzer_imports/analyzer_imports_test.dart
+++ b/test/analyzers/file_analyzers/analyzer_imports/analyzer_imports_test.dart
@@ -115,4 +115,40 @@ void main() {
       expect(lints.length, 0);
     },
   );
+
+  test(
+    'Tests if analyzer detects banned imports even when valid import is first',
+    () async {
+      final domainClassUnit = await FileParseHelper.parseTestFile(
+        '${domainPath}domain_class_valid_import_first.dart',
+      ) as ResolvedUnitResult;
+
+      final lints = architectureAnalyzerImports.runAnalysis(
+        domainClassUnit,
+        config,
+      );
+
+      // Should detect the banned import to presentation layer
+      // even though a valid import to domain layer comes first
+      expect(lints.length, 1);
+    },
+  );
+
+  test(
+    'Tests if analyzer detects banned imports after external package imports',
+    () async {
+      final domainClassUnit = await FileParseHelper.parseTestFile(
+        '${domainPath}domain_class_package_import_first.dart',
+      ) as ResolvedUnitResult;
+
+      final lints = architectureAnalyzerImports.runAnalysis(
+        domainClassUnit,
+        config,
+      );
+
+      // Should detect the banned import to presentation layer
+      // even though an external package import comes first
+      expect(lints.length, 1);
+    },
+  );
 }

--- a/test/mocks/domain/domain_class_package_import_first.dart
+++ b/test/mocks/domain/domain_class_package_import_first.dart
@@ -1,0 +1,13 @@
+// Test case for bug where banned imports after external package imports were not detected
+// Simulating real-world scenario with Flutter/package imports
+
+import 'package:test/test.dart'; // External package import
+import '../presentation/presentation_class.dart'; // Banned import
+
+class DomainClassWithPackageImportFirst {
+  final PresentationClass presentationClass = PresentationClass();
+
+  void runTest() {
+    expect(presentationClass, isNotNull);
+  }
+}

--- a/test/mocks/domain/domain_class_valid_import_first.dart
+++ b/test/mocks/domain/domain_class_valid_import_first.dart
@@ -1,0 +1,10 @@
+// Test case for bug where banned imports after valid imports were not detected
+// This tests that the analyzer continues checking all imports, not just the first one
+
+import '../domain/get_user_data_use_case.dart'; // Valid import (same layer)
+import '../presentation/presentation_class.dart'; // Banned import
+
+class DomainClassWithValidImportFirst {
+  final GetUserDataUseCase useCase = GetUserDataUseCase();
+  final PresentationClass presentationClass = PresentationClass();
+}

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -1,9 +1,9 @@
 name: architecture_linter_analyzer_plugin_loader
 description: This pubspec determines the version of the analyzer plugin to load.
-version: 0.3.0
+version: 0.3.1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
-  architecture_linter: ^0.3.0
+  architecture_linter: ^0.3.1


### PR DESCRIPTION
I noticed a bug where an allowed import is the first on the file other preceding banned imports are ignored. Added a case for it in the example and tests.